### PR TITLE
Removed Alphaleonis usage

### DIFF
--- a/KnowYourEnemyMutagen/KnowYourEnemyMutagen.csproj
+++ b/KnowYourEnemyMutagen/KnowYourEnemyMutagen.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mutagen.Bethesda" Version="0.22.0" />
+        <PackageReference Include="Mutagen.Bethesda" Version="0.25.0" />
         <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
-        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.12.0" />
+        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.13.2" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 

--- a/KnowYourEnemyMutagen/Program.cs
+++ b/KnowYourEnemyMutagen/Program.cs
@@ -5,11 +5,10 @@ using Mutagen.Bethesda;
 using Mutagen.Bethesda.Synthesis;
 using Mutagen.Bethesda.Skyrim;
 using Newtonsoft.Json.Linq;
-using Alphaleonis.Win32.Filesystem;
 using Mutagen.Bethesda.FormKeys.SkyrimSE;
 using Newtonsoft.Json;
 using Noggog;
-using System.Reflection.Metadata.Ecma335;
+using System.IO;
 
 namespace KnowYourEnemyMutagen
 {


### PR DESCRIPTION
Upcoming mutagen version won't have access to Alphaleonis implicitly.  System.IO should do fine